### PR TITLE
Switching time units from metric system to block number system

### DIFF
--- a/solidity/contracts/FakturVerifier.sol
+++ b/solidity/contracts/FakturVerifier.sol
@@ -33,7 +33,7 @@ contract FakturVerifier {
        - documentation
        - tests
     */
-    function FakturVerifier() public {
+    function pakturVerifier() public {
         OracleAddress = msg.sender;
         challengePeriod = 1 days; // SLA
         lastTimestamp = 0;
@@ -46,7 +46,7 @@ contract FakturVerifier {
         @param hash is the targetHash
         @param timestamp should be the time limit of the promise
     */
-    function ProofID(bytes32 hash, uint timestamp) pure public returns (bytes32) {
+    function proofID(bytes32 hash, uint timestamp) pure public returns (bytes32) {
         return keccak256(hash, timestamp);
     }
 
@@ -60,13 +60,13 @@ contract FakturVerifier {
         @param r, r part of the "personalSignature"
         @param s, s part of the "personalSignature"
     */
-    function ChallengeReceipt(bytes32 targetHash, uint timestamp, uint8 v , bytes32 r , bytes32 s) public payable {
+    function challengeReceipt(bytes32 targetHash, uint timestamp, uint8 v , bytes32 r , bytes32 s) public payable {
         // Verify period validity
         require(timestamp < now);
         require(msg.value >= minimalAmount);
         require(receipts[targetHash].PayTo == 0x0); // No withdrawl pending or pending deletion
         bytes memory prefix = "\x19Ethereum Signed Message:\n32";
-        bytes32 preProofID = ProofID(targetHash, timestamp);
+        bytes32 preProofID = proofID(targetHash, timestamp);
         bytes32 prefixHash = keccak256(prefix, preProofID);
         require(ecrecover(prefixHash, v, r, s) == OracleAddress);
         // Register challenge
@@ -96,9 +96,9 @@ contract FakturVerifier {
         @param proofs, hash audit path
         @param targetHash, user generated hash
     */
-    function CancelChallenge(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) onlyOwner public {
+    function cancelChallenge(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) onlyOwner public {
         require(receipts[targetHash].Timeout < now);
-        if (VerifyMerkleHash(leafPos, proofs, targetHash)) {
+        if (verifyMerkleHash(leafPos, proofs, targetHash)) {
             //Receipt exist at least by the publication of this transaction
             receipts[targetHash].Timeout = 0;
             emit ChallengeCancelled(targetHash, receipts[targetHash].PayTo);
@@ -115,14 +115,14 @@ contract FakturVerifier {
         assembly {
                 merkleRoot := mload(add(data, 32))
         }
-        Anchor(merkleRoot);
+        anchor(merkleRoot);
     }
 
     /*
         @dev Timestamp function, register merkleRoots
         @param hash, Register merkleRoot provided by Oracle
     */
-    function Anchor(bytes32 hash) onlyOwner public {
+    function anchor(bytes32 hash) onlyOwner public {
         hashs[hash] = now;
         lastTimestamp = now;
         emit NotifyAnchor(hash, now, msg.sender);
@@ -146,7 +146,7 @@ contract FakturVerifier {
         @param proofs, hash audit path
         @param targetHash, user generated hash
     */
-    function VerifyMerkleHash(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
+    function verifyMerkleHash(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
         require(leafPos.length == proofs.length);
         // Did we anchor this ?
         // targetHash == merkleRoot when tree contain only 1 element
@@ -179,7 +179,7 @@ contract FakturVerifier {
         @param proofs, hash audit path
         @param targetHash, user generated hash
     */
-    function VerifyRFC6962(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
+    function verifyRFC6962(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
         require(leafPos.length == proofs.length);
         bytes32 proofHash = sha256(byte(0x0), targetHash);
         for (uint256 j = 0; j < proofs.length; j++) {

--- a/solidity/contracts/FakturVerifier.sol
+++ b/solidity/contracts/FakturVerifier.sol
@@ -1,195 +1,196 @@
 pragma solidity ^0.4.21;
 
+
 contract FakturVerifier {
-	address OracleAddress;
+    address OracleAddress;
 
-	uint LastTimestamp;
-	uint ChallengePeriod;
-	uint MinimalAmount;
+    uint lastTimestamp;
+    uint challengePeriod;
+    uint minimalAmount;
 
-	// Merkle root
-	mapping(bytes32 => uint) Hashs;
-	// Hash of specific file
-	mapping(bytes32 => Receipt) Receipts;
+    // Merkle root
+    mapping(bytes32 => uint) hashs;
+    // Hash of specific file
+    mapping(bytes32 => Receipt) receipts;
 
-	event NotifyAnchor(bytes32 hash, uint timestamp, address oracle);
-	event Challenge(bytes32 hash, uint timestamp);
-	event ChallengeCancelled(bytes32 hash, address whom);
+    event NotifyAnchor(bytes32 hash, uint timestamp, address oracle);
+    event Challenge(bytes32 hash, uint timestamp);
+    event ChallengeCancelled(bytes32 hash, address whom);
 
-	struct Receipt {
-		address		PayTo;
-		uint		Amount;
-		uint		Timeout;
-	}
+    struct Receipt {
+        address        PayTo;
+        uint        Amount;
+        uint        Timeout;
+    }
 
-	modifier onlyOwner () {
-		require(OracleAddress == msg.sender);
-		_;
-	}
+    modifier onlyOwner () {
+        require(OracleAddress == msg.sender);
+        _;
+    }
 
-	/*
-	  TODO:
-	   - documentation
-	   - tests
-	*/
-	function FakturVerifier() public {
-		OracleAddress = msg.sender;
-		ChallengePeriod = 1 days; // SLA
-		LastTimestamp = 0;
-		MinimalAmount = 0.1 ether;
-		
-	}
+    /*
+      TODO:
+       - documentation
+       - tests
+    */
+    function FakturVerifier() public {
+        OracleAddress = msg.sender;
+        challengePeriod = 1 days; // SLA
+        lastTimestamp = 0;
+        minimalAmount = 0.1 ether;
+        
+    }
 
-	/*
-		@dev Generate a promise the Oracle should signed.
-		@param hash is the targetHash
-		@param timestamp should be the time limit of the promise
-	*/
-	function ProofID(bytes32 hash, uint timestamp) pure public returns (bytes32) {
-		return keccak256(hash, timestamp);
-	}
+    /*
+        @dev Generate a promise the Oracle should signed.
+        @param hash is the targetHash
+        @param timestamp should be the time limit of the promise
+    */
+    function ProofID(bytes32 hash, uint timestamp) pure public returns (bytes32) {
+        return keccak256(hash, timestamp);
+    }
 
-	/*
-		@dev Open a challenge window for the oracle to submit the receipt
-			if no proof is submitted thourgh CancelChallenge, the amount sent
-			will be refund plus reimbursent (TODO)
-		@param targetHash, user generated hash
-		@param timestamp, promised timestamping limit
-		@param v, v part of the "personalSignature"
-		@param r, r part of the "personalSignature"
-		@param s, s part of the "personalSignature"
-	*/
-	function ChallengeReceipt(bytes32 targetHash, uint timestamp, uint8 v , bytes32 r , bytes32 s) public payable {
-		// Verify period validity
-		require(timestamp < now);
-		require(msg.value >= MinimalAmount);
-		require(Receipts[targetHash].PayTo == 0x0); // No withdrawl pending or pending deletion
-		bytes memory prefix = "\x19Ethereum Signed Message:\n32";
-		bytes32 preProofID = ProofID(targetHash, timestamp);
-		bytes32 prefixHash = keccak256(prefix, preProofID);
-		require(ecrecover(prefixHash, v, r, s) == OracleAddress);
-		// Register challenge
-		uint timeout = now + ChallengePeriod;
-		Receipts[targetHash].PayTo = msg.sender;
-		Receipts[targetHash].Amount = msg.value /* + calculate delta for paid anchor */;
-		Receipts[targetHash].Timeout = timeout;
-		// Emit event w/ hash and timeout
-		emit Challenge(targetHash, timeout);
-	}
+    /*
+        @dev Open a challenge window for the oracle to submit the receipt
+            if no proof is submitted thourgh CancelChallenge, the amount sent
+            will be refund plus reimbursent (TODO)
+        @param targetHash, user generated hash
+        @param timestamp, promised timestamping limit
+        @param v, v part of the "personalSignature"
+        @param r, r part of the "personalSignature"
+        @param s, s part of the "personalSignature"
+    */
+    function ChallengeReceipt(bytes32 targetHash, uint timestamp, uint8 v , bytes32 r , bytes32 s) public payable {
+        // Verify period validity
+        require(timestamp < now);
+        require(msg.value >= minimalAmount);
+        require(receipts[targetHash].PayTo == 0x0); // No withdrawl pending or pending deletion
+        bytes memory prefix = "\x19Ethereum Signed Message:\n32";
+        bytes32 preProofID = ProofID(targetHash, timestamp);
+        bytes32 prefixHash = keccak256(prefix, preProofID);
+        require(ecrecover(prefixHash, v, r, s) == OracleAddress);
+        // Register challenge
+        uint timeout = now + challengePeriod;
+        receipts[targetHash].PayTo = msg.sender;
+        receipts[targetHash].Amount = msg.value /* + calculate delta for paid anchor */;
+        receipts[targetHash].Timeout = timeout;
+        // Emit event w/ hash and timeout
+        emit Challenge(targetHash, timeout);
+    }
 
-	/*
-		@dev Reimburse non timestamped hash
-		@param targetHash, user generated hash
-	*/
-	function WithdrawChallenge(bytes32 targetHash) public {
-		require(Receipts[targetHash].Timeout >= now);
-		address payto = Receipts[targetHash].PayTo;
-		uint amount = Receipts[targetHash].Amount;
-		delete Receipts[targetHash];
-		payto.transfer(amount);
-	}
+    /*
+        @dev Reimburse non timestamped hash
+        @param targetHash, user generated hash
+    */
+    function withdrawChallenge(bytes32 targetHash) public {
+        require(receipts[targetHash].Timeout >= now);
+        address payto = receipts[targetHash].PayTo;
+        uint amount = receipts[targetHash].Amount;
+        delete receipts[targetHash];
+        payto.transfer(amount);
+    }
 
-	/*
-		@dev Cancel challenge by providing proof
-		@param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
-		@param proofs, hash audit path
-		@param targetHash, user generated hash
-	*/
-	function CancelChallenge(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) onlyOwner public {
-		require(Receipts[targetHash].Timeout < now);
-		if (VerifyMerkleHash(leafPos, proofs, targetHash)) {
-			//Receipt exist at least by the publication of this transaction
-			Receipts[targetHash].Timeout = 0;
-			emit ChallengeCancelled(targetHash, Receipts[targetHash].PayTo);
-			return;
-		}
-	}
+    /*
+        @dev Cancel challenge by providing proof
+        @param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
+        @param proofs, hash audit path
+        @param targetHash, user generated hash
+    */
+    function CancelChallenge(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) onlyOwner public {
+        require(receipts[targetHash].Timeout < now);
+        if (VerifyMerkleHash(leafPos, proofs, targetHash)) {
+            //Receipt exist at least by the publication of this transaction
+            receipts[targetHash].Timeout = 0;
+            emit ChallengeCancelled(targetHash, receipts[targetHash].PayTo);
+            return;
+        }
+    }
 
-	// To be Chainpoint 2.1 compliant TODO verify others verification system
-	function () onlyOwner public {
-		require(msg.data.length == 32);
-		bytes memory data = msg.data;
-		bytes32 merkleRoot;
-		// length is at msg.data[0]
-		assembly {
-				merkleRoot := mload(add(data, 32))
-		}
-		Anchor(merkleRoot);
-	}
+    // To be Chainpoint 2.1 compliant TODO verify others verification system
+    function () onlyOwner public {
+        require(msg.data.length == 32);
+        bytes memory data = msg.data;
+        bytes32 merkleRoot;
+        // length is at msg.data[0]
+        assembly {
+                merkleRoot := mload(add(data, 32))
+        }
+        Anchor(merkleRoot);
+    }
 
-	/*
-		@dev Timestamp function, register merkleRoots
-		@param hash, Register merkleRoot provided by Oracle
-	*/
-	function Anchor(bytes32 hash) onlyOwner public {
-		Hashs[hash] = now;
-		LastTimestamp = now;
-		emit NotifyAnchor(hash, now, msg.sender);
-	}
+    /*
+        @dev Timestamp function, register merkleRoots
+        @param hash, Register merkleRoot provided by Oracle
+    */
+    function Anchor(bytes32 hash) onlyOwner public {
+        hashs[hash] = now;
+        lastTimestamp = now;
+        emit NotifyAnchor(hash, now, msg.sender);
+    }
 
-	/*
-		@dev Verify Chainpoint v2 flavor
-			Deprecated because provided hash could be part of a deeper receipt
-		      root
-		      / \
-		     /   \
-		    /     \
-		    C      D
-		   / \     |
-		   A B     h2
-		   | |
-		  h0 h1
-		 / \
-		 X Y
-		@param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
-		@param proofs, hash audit path
-		@param targetHash, user generated hash
-	*/
-	function VerifyMerkleHash(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
-		require(leafPos.length == proofs.length);
-		// Did we anchor this ?
-		// targetHash == merkleRoot when tree contain only 1 element
-		bytes32 proofHash = targetHash;
-		for (uint256 j = 0; j < proofs.length; j++) {
-			bytes32 leaf = proofs[j];
-			if (leafPos[j]) {
-				proofHash = sha256(leaf, proofHash); // proof on the right (true)
-			} else {
-				proofHash = sha256(proofHash, leaf);  // proof on the left (false)
-			}
-		}
-		return Hashs[proofHash] > 0;
-	}
+    /*
+        @dev Verify Chainpoint v2 flavor
+            Deprecated because provided hash could be part of a deeper receipt
+              root
+              / \
+             /   \
+            /     \
+            C      D
+           / \     |
+           A B     h2
+           | |
+          h0 h1
+         / \
+         X Y
+        @param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
+        @param proofs, hash audit path
+        @param targetHash, user generated hash
+    */
+    function VerifyMerkleHash(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
+        require(leafPos.length == proofs.length);
+        // Did we anchor this ?
+        // targetHash == merkleRoot when tree contain only 1 element
+        bytes32 proofHash = targetHash;
+        for (uint256 j = 0; j < proofs.length; j++) {
+            bytes32 leaf = proofs[j];
+            if (leafPos[j]) {
+                proofHash = sha256(leaf, proofHash); // proof on the right (true)
+            } else {
+                proofHash = sha256(proofHash, leaf);  // proof on the left (false)
+            }
+        }
+        return hashs[proofHash] > 0;
+    }
 
-	//TODO optimize with bitfields and bytes
-	/*
-		@dev Verify rfc6962 Merkle Hash Tree with second preimage resistance
-	          root
-	          / \
-	         /   \
-	        /     \
-	       C       D
-	      / \      |
-	     A   B     h2
-	     |   |
-	    h0   h1
-	 left          right
-		@param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
-		@param proofs, hash audit path
-		@param targetHash, user generated hash
-	*/
-	function VerifyRFC6962(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
-		require(leafPos.length == proofs.length);
-		bytes32 proofHash = sha256(byte(0x0), targetHash);
-		for (uint256 j = 0; j < proofs.length; j++) {
-			bytes32 leaf = proofs[j];
-			if (leafPos[j]) {
-				proofHash = sha256(byte(0x1), leaf, proofHash); // proof on the right (true)
-			} else {
-				proofHash = sha256(byte(0x1), proofHash, leaf); // proof on the left (false)
-			}
-		}
-		// Did we anchor this ?
-		return Hashs[proofHash] > 0;
-	}
+    //TODO optimize with bitfields and bytes
+    /*
+        @dev Verify rfc6962 Merkle Hash Tree with second preimage resistance
+              root
+              / \
+             /   \
+            /     \
+           C       D
+          / \      |
+         A   B     h2
+         |   |
+        h0   h1
+     left          right
+        @param leafPos, Proof position on Merkle Tree (true -> right, false -> left)
+        @param proofs, hash audit path
+        @param targetHash, user generated hash
+    */
+    function VerifyRFC6962(bool[] leafPos, bytes32[] proofs, bytes32 targetHash) view public returns (bool) {
+        require(leafPos.length == proofs.length);
+        bytes32 proofHash = sha256(byte(0x0), targetHash);
+        for (uint256 j = 0; j < proofs.length; j++) {
+            bytes32 leaf = proofs[j];
+            if (leafPos[j]) {
+                proofHash = sha256(byte(0x1), leaf, proofHash); // proof on the right (true)
+            } else {
+                proofHash = sha256(byte(0x1), proofHash, leaf); // proof on the left (false)
+            }
+        }
+        // Did we anchor this ?
+        return hashs[proofHash] > 0;
+    }
 }

--- a/solidity/contracts/FakturVerifier.sol
+++ b/solidity/contracts/FakturVerifier.sol
@@ -35,7 +35,7 @@ contract FakturVerifier {
     */
     function pakturVerifier() public {
         OracleAddress = msg.sender;
-        challengePeriod = (24*60*60)/15 // SLA
+        challengePeriod = (24*60*60)/15; // SLA // convert 1 day to number of blocks. As 1 block ~= 15 secs => (24h * 60mins * 60secs) / 15secs = 5760 blocks
         lastTimestamp = 0;
         minimalAmount = 0.1 ether;
         

--- a/solidity/contracts/FakturVerifier.sol
+++ b/solidity/contracts/FakturVerifier.sol
@@ -35,7 +35,7 @@ contract FakturVerifier {
     */
     function pakturVerifier() public {
         OracleAddress = msg.sender;
-        challengePeriod = 1 days; // SLA
+        challengePeriod = (24*60*60)/15 // SLA
         lastTimestamp = 0;
         minimalAmount = 0.1 ether;
         


### PR DESCRIPTION
As discussed [here ](https://github.com/Magicking/faktur/issues/1), this branch contains the following modifications : 

- Removed tab indentation to put 4 spaces instead
- Renaming methods to mixedCamelCase 
- Switching timestamp from `now` to `block.number`
- Switching challengePeriod from `1 day` to `5760` as there should be around (24*60*60) /15 per day. (1)

(1) It is important for user to then consider that challengePeriod might not expire in an absolute period defined in metric system as block generation relies on difficulty of PoW regarding the available hashpower deployed on the network. However this brings more security as it's impossible for a miner to trick the block number, which wouldn't be the case with metric system time unit. 

 